### PR TITLE
Update the HLT TRD tracker

### DIFF
--- a/HLT/TRD/tracking/AliHLTTRDTracker.h
+++ b/HLT/TRD/tracking/AliHLTTRDTracker.h
@@ -39,7 +39,7 @@ public:
   void DoTracking(AliExternalTrackParam *tracksTPC, int *tracksTPCLab, int nTPCTracks);
   void CalculateSpacePoints();
   int FollowProlongation(AliHLTTRDTrack *t, double mass);
-  void EnableDebugOutput() { fEnableDebugOutput = true; }
+  void EnableDebugOutput() { fDebugOutput = true; }
   void SetPtThreshold(float minPt) { fMinPt = minPt; }
   void SetChi2Threshold(float maxChi2) { fMaxChi2 = maxChi2; }
   void Rotate(const double alpha, const double * const loc, double *glb);
@@ -86,7 +86,7 @@ protected:
                                               // and number of tracklets in detector [iDet][1]
   AliHLTTRDSpacePointInternal *fSpacePoints;  // array with tracklet coordinates in global tracking frame
   AliTRDgeometry *fTRDgeometry;               // TRD geometry
-  bool fEnableDebugOutput;                    // store debug output
+  bool fDebugOutput;                          // store debug output
   float fMinPt;                               // min pt of TPC tracks for tracking
   float fMaxChi2;                             // max chi2 for tracklets
   TTreeSRedirector *fStreamer;                // debug output stream

--- a/HLT/global/AliHLTGlobalEsdConverterComponent.cxx
+++ b/HLT/global/AliHLTGlobalEsdConverterComponent.cxx
@@ -1178,6 +1178,7 @@ int AliHLTGlobalEsdConverterComponent::ProcessBlocks(TTree* pTree, AliESDEvent* 
 	tESD->UpdateTrackParams(&trdTrack,AliESDtrack::kTRDout);
 	tESD->SetStatus(AliESDtrack::kTRDin);
 	tESD->SetTRDpid(TRDpid);
+  tESD->SetTRDntracklets(trdTrack.GetNtracklets() << 3);
 
 	if( pESDfriend ) { 
 	  AliESDfriendTrack *friendTrack = pESDfriend->GetTrack(esdID);
@@ -1203,7 +1204,7 @@ int AliHLTGlobalEsdConverterComponent::ProcessBlocks(TTree* pTree, AliESDEvent* 
 	}
       }
       if( iResult>=0 ){    
-	HLTInfo("converted %d track(s) to AliESDtrack and added to ESD", trackData->fCount);
+	HLTInfo("converted %d TRD track(s) to AliESDtrack and added to ESD", trackData->fCount);
 	iAddedDataBlocks++;
       } else {
 	HLTError("can not extract tracks from data block of type %s (specification %08x) of size %d: error %d", 


### PR DESCRIPTION
Introduces minor changes to the HLT TRD tracker. Eta cut, MC label propagation, radial extrapolation of tracks to the anode position of the respective chamber, no back propagation of tracks after tracking. Furthermore, in the ESD converter the number of attached TRD tracklets is written to the tracks (only if TRD is enabled, by default it is disabled).