### PR TITLE
HWCFEmulator: bugfix for pad deconvolution flags

### DIFF
--- a/HLT/TPCLib/HWCFemulator/AliHLTTPCHWCFMergerUnit.cxx
+++ b/HLT/TPCLib/HWCFemulator/AliHLTTPCHWCFMergerUnit.cxx
@@ -228,6 +228,7 @@ const AliHLTTPCHWCFClusterFragment *AliHLTTPCHWCFMergerUnit::OutputStream()
       fInput.fP += s.fP;
       fInput.fP2 += s.fP2;
       fInput.fBorder |= s.fBorder;
+      fInput.fIsDeconvolutedPad |= s.fIsDeconvolutedPad;
 	  fInput.fEdge |= s.fEdge;
       fInput.fMC.insert(fInput.fMC.end(), s.fMC.begin(), s.fMC.end());
       if (s.fLargestQ > fInput.fLargestQ)


### PR DESCRIPTION
The `fIsDeconvolutedPad` flag from a previous deconvolution was not propagated to
the resulting second cluster if additional fragments were added to the second
cluster.