### PR TITLE
Update TRD tracker

### DIFF
--- a/HLT/TRD/tracking/AliHLTTRDTracker.cxx
+++ b/HLT/TRD/tracking/AliHLTTRDTracker.cxx
@@ -288,6 +288,7 @@ void AliHLTTRDTracker::CalculateSpacePoints()
       }
       matrix->LocalToMaster(xTrklt, fSpacePoints[trkltIdx].fX);
       fSpacePoints[trkltIdx].fId = fTracklets[trkltIdx].GetId();
+      fSpacePoints[trkltIdx].fLabel = fTracklets[trkltIdx].GetLabel();
       fSpacePoints[trkltIdx].fCov[0] = 0.03;
       fSpacePoints[trkltIdx].fCov[1] = padPlane->GetRowPos(fTracklets[trkltIdx].GetZbin()) / TMath::Sqrt(12);
 

--- a/HLT/TRD/tracking/AliHLTTRDTracker.h
+++ b/HLT/TRD/tracking/AliHLTTRDTracker.h
@@ -31,6 +31,7 @@ public:
     double fX[3];
     double fCov[2];
     int fId;
+    int fLabel;
     unsigned short fVolumeId;
   };
 

--- a/HLT/TRD/tracking/AliHLTTRDTracker.h
+++ b/HLT/TRD/tracking/AliHLTTRDTracker.h
@@ -21,6 +21,7 @@ public:
 
   enum EHLTTRDTracker {
     kNLayers = 6,
+    kNStacks = 5,
     kNSectors = 18,
     kNChambers = 540
   };
@@ -28,6 +29,7 @@ public:
   // struct to hold the information on the space points
   struct AliHLTTRDSpacePointInternal {
     double fX[3];
+    double fCov[2];
     int fId;
     unsigned short fVolumeId;
   };

--- a/HLT/TRD/tracking/AliHLTTRDTracker.h
+++ b/HLT/TRD/tracking/AliHLTTRDTracker.h
@@ -44,7 +44,6 @@ public:
   void EnableDebugOutput() { fDebugOutput = true; }
   void SetPtThreshold(float minPt) { fMinPt = minPt; }
   void SetChi2Threshold(float maxChi2) { fMaxChi2 = maxChi2; }
-  void Rotate(const double alpha, const double * const loc, double *glb);
   int GetDetectorNumber(const double zPos, double alpha, int layer);
   bool AdjustSector(AliHLTTRDTrack *t);
 

--- a/HLT/TRD/tracking/AliHLTTRDTrackletWord.cxx
+++ b/HLT/TRD/tracking/AliHLTTRDTrackletWord.cxx
@@ -34,6 +34,7 @@ AliTRDgeometry* AliHLTTRDTrackletWord::fgGeo = 0x0;
 
 AliHLTTRDTrackletWord::AliHLTTRDTrackletWord(UInt_t trackletWord) :
   fId(-1),
+  fLabel(-1),
   fHCId(-1),
   fTrackletWord(trackletWord)
 {
@@ -41,8 +42,9 @@ AliHLTTRDTrackletWord::AliHLTTRDTrackletWord(UInt_t trackletWord) :
     fgGeo = new AliTRDgeometry;
 }
 
-AliHLTTRDTrackletWord::AliHLTTRDTrackletWord(UInt_t trackletWord, Int_t hcid, Int_t id) :
+AliHLTTRDTrackletWord::AliHLTTRDTrackletWord(UInt_t trackletWord, Int_t hcid, Int_t id, Int_t label) :
   fId(id),
+  fLabel(label),
   fHCId(hcid),
   fTrackletWord(trackletWord)
 {
@@ -52,6 +54,7 @@ AliHLTTRDTrackletWord::AliHLTTRDTrackletWord(UInt_t trackletWord, Int_t hcid, In
 
 AliHLTTRDTrackletWord::AliHLTTRDTrackletWord(const AliHLTTRDTrackletWord &rhs) :
   fId(rhs.fId),
+  fLabel(rhs.fLabel),
   fHCId(rhs.fHCId),
   fTrackletWord(rhs.fTrackletWord)
 {
@@ -62,6 +65,7 @@ AliHLTTRDTrackletWord::AliHLTTRDTrackletWord(const AliHLTTRDTrackletWord &rhs) :
 
 AliHLTTRDTrackletWord::AliHLTTRDTrackletWord(const AliTRDtrackletWord &rhs) :
   fId(-1),
+  fLabel(-1),
   fHCId(rhs.GetHCId()),
   fTrackletWord(rhs.GetTrackletWord())
 {
@@ -72,6 +76,7 @@ AliHLTTRDTrackletWord::AliHLTTRDTrackletWord(const AliTRDtrackletWord &rhs) :
 
 AliHLTTRDTrackletWord::AliHLTTRDTrackletWord(const AliTRDtrackletMCM &rhs) :
   fId(-1),
+  fLabel(-1), // try rhs.GetLabel()[0] ?
   fHCId(rhs.GetHCId()),
   fTrackletWord(rhs.GetTrackletWord())
 {

--- a/HLT/TRD/tracking/AliHLTTRDTrackletWord.h
+++ b/HLT/TRD/tracking/AliHLTTRDTrackletWord.h
@@ -21,7 +21,7 @@ class AliTRDtrackletMCM;
 class AliHLTTRDTrackletWord {
  public:
   AliHLTTRDTrackletWord(UInt_t trackletWord = 0);
-  AliHLTTRDTrackletWord(UInt_t trackletWord, Int_t hcid, Int_t id);
+  AliHLTTRDTrackletWord(UInt_t trackletWord, Int_t hcid, Int_t id, Int_t label = -1);
   AliHLTTRDTrackletWord(const AliHLTTRDTrackletWord &rhs);
   AliHLTTRDTrackletWord(const AliTRDtrackletWord &rhs);
   AliHLTTRDTrackletWord(const AliTRDtrackletMCM &rhs);
@@ -41,7 +41,9 @@ class AliHLTTRDTrackletWord {
 
   Int_t GetROB() const;
   Int_t GetMCM() const;
+
   Int_t GetId() const { return fId; }
+  Int_t GetLabel() const { return fLabel; }
 
   // ----- Getters for offline corresponding values -----
   Bool_t CookPID() { return kFALSE; }
@@ -60,10 +62,12 @@ class AliHLTTRDTrackletWord {
   void SetTrackletWord(UInt_t trackletWord) { fTrackletWord = trackletWord; }
   void SetDetector(Int_t id) { fHCId = 2 * id + (GetYbin() < 0 ? 0 : 1); }
   void SetId(Int_t id) { fId = id; }
+  void SetLabel(Int_t label) { fLabel = label; }
   void SetHCId(Int_t id) { fHCId = id; }
 
  protected:
   Int_t fId;              // index in tracklet array
+  Int_t fLabel;           // MC label
   Int_t fHCId;            // half-chamber ID
   UInt_t fTrackletWord;   // tracklet word: PID | Z | deflection length | Y
                           //          bits:   8   4            7          13


### PR DESCRIPTION
- TRD space points get covariance matrix to account for different z error depending on pad length
- Tracklets and tracks are now compared at the same radial position
- Space points also get MC label