### PR TITLE
use 3 MC labels for ESDTrdTracklets

### DIFF
--- a/HLT/TRD/AliTRDonlineTrackingDataContainer.cxx
+++ b/HLT/TRD/AliTRDonlineTrackingDataContainer.cxx
@@ -102,7 +102,7 @@ Float_t AliTRDonlineTrackingDataContainer::GetTrackletLocalY(UInt_t det, UInt_t 
 AliESDTrdTracklet* AliTRDonlineTrackingDataContainer::GetTracklet(UInt_t det, UInt_t trackletIndex) {
   AliESDTrdTracklet* trkl = NULL;
   if ((det < fgkNumChambers) && (trackletIndex < fNumTracklets[det])){
-    trkl = new AliESDTrdTracklet(fTrackletWords[det][trackletIndex], fTrackletHCId[det][trackletIndex], -1);
+    trkl = new AliESDTrdTracklet(fTrackletWords[det][trackletIndex], fTrackletHCId[det][trackletIndex], 0);
   }
   return trkl;
 }

--- a/HLT/TRD/tracking/AliHLTTRDTracker.h
+++ b/HLT/TRD/tracking/AliHLTTRDTracker.h
@@ -34,7 +34,7 @@ public:
     double fCov[2];           // sigma_y^2, sigma_yz, sigma_z^2
     double fDy;               // deflection over drift length
     int fId;                  // index
-    int fLabel;               // MC label
+    int fLabel[3];            // MC labels
     unsigned short fVolumeId; // basically derived from TRD chamber number
   };
 

--- a/HLT/TRD/tracking/AliHLTTRDTrackletWord.cxx
+++ b/HLT/TRD/tracking/AliHLTTRDTrackletWord.cxx
@@ -34,53 +34,55 @@ AliTRDgeometry* AliHLTTRDTrackletWord::fgGeo = 0x0;
 
 AliHLTTRDTrackletWord::AliHLTTRDTrackletWord(UInt_t trackletWord) :
   fId(-1),
-  fLabel(-1),
   fHCId(-1),
   fTrackletWord(trackletWord)
 {
+  for (int i=3;i--;) fLabel[i] = -1;
   if (!fgGeo)
     fgGeo = new AliTRDgeometry;
 }
 
-AliHLTTRDTrackletWord::AliHLTTRDTrackletWord(UInt_t trackletWord, Int_t hcid, Int_t id, Int_t label) :
+AliHLTTRDTrackletWord::AliHLTTRDTrackletWord(UInt_t trackletWord, Int_t hcid, Int_t id, Int_t* label) :
   fId(id),
-  fLabel(label),
   fHCId(hcid),
   fTrackletWord(trackletWord)
 {
+  if (label) {
+    for (int i=3;i--;) fLabel[i] = label[i];
+  }
+  else {
+    for (int i=3;i--;) fLabel[i] = -1;
+  }
   if (!fgGeo)
     fgGeo = new AliTRDgeometry;
 }
 
 AliHLTTRDTrackletWord::AliHLTTRDTrackletWord(const AliHLTTRDTrackletWord &rhs) :
   fId(rhs.fId),
-  fLabel(rhs.fLabel),
   fHCId(rhs.fHCId),
   fTrackletWord(rhs.fTrackletWord)
 {
-
+  for (int i=3;i--;) fLabel[i] =  rhs.fLabel[i];
   if (!fgGeo)
     fgGeo = new AliTRDgeometry;
 }
 
 AliHLTTRDTrackletWord::AliHLTTRDTrackletWord(const AliTRDtrackletWord &rhs) :
   fId(-1),
-  fLabel(-1),
   fHCId(rhs.GetHCId()),
   fTrackletWord(rhs.GetTrackletWord())
 {
-
+  for (int i=3;i--;) fLabel[i] = -1;
   if (!fgGeo)
     fgGeo = new AliTRDgeometry;
 }
 
 AliHLTTRDTrackletWord::AliHLTTRDTrackletWord(const AliTRDtrackletMCM &rhs) :
   fId(-1),
-  fLabel(-1), // try rhs.GetLabel()[0] ?
   fHCId(rhs.GetHCId()),
   fTrackletWord(rhs.GetTrackletWord())
 {
-
+  for (int i=3;i--;) fLabel[i] =  rhs.GetLabel(i);
   if (!fgGeo)
     fgGeo = new AliTRDgeometry;
 }

--- a/HLT/TRD/tracking/AliHLTTRDTrackletWord.h
+++ b/HLT/TRD/tracking/AliHLTTRDTrackletWord.h
@@ -21,7 +21,7 @@ class AliTRDtrackletMCM;
 class AliHLTTRDTrackletWord {
  public:
   AliHLTTRDTrackletWord(UInt_t trackletWord = 0);
-  AliHLTTRDTrackletWord(UInt_t trackletWord, Int_t hcid, Int_t id, Int_t label = -1);
+  AliHLTTRDTrackletWord(UInt_t trackletWord, Int_t hcid, Int_t id, Int_t *label = 0);
   AliHLTTRDTrackletWord(const AliHLTTRDTrackletWord &rhs);
   AliHLTTRDTrackletWord(const AliTRDtrackletWord &rhs);
   AliHLTTRDTrackletWord(const AliTRDtrackletMCM &rhs);
@@ -43,8 +43,9 @@ class AliHLTTRDTrackletWord {
   Int_t GetMCM() const;
 
   Int_t GetId() const { return fId; }
-  Int_t GetLabel() const { return fLabel; }
-
+  const Int_t* GetLabel() const { return fLabel; }
+  Int_t GetLabel(int i=0) const { return fLabel[i];}
+  
   // ----- Getters for offline corresponding values -----
   Bool_t CookPID() { return kFALSE; }
   Double_t GetPID(Int_t /* is */) const { return (Double_t) GetPID()/256.; }
@@ -62,12 +63,13 @@ class AliHLTTRDTrackletWord {
   void SetTrackletWord(UInt_t trackletWord) { fTrackletWord = trackletWord; }
   void SetDetector(Int_t id) { fHCId = 2 * id + (GetYbin() < 0 ? 0 : 1); }
   void SetId(Int_t id) { fId = id; }
-  void SetLabel(Int_t label) { fLabel = label; }
+  void SetLabel(const Int_t *label) { for (int i=3;i--;) fLabel[i] = label[i]; }
+  void SetLabel(int i, int label) { fLabel[i] = label; }
   void SetHCId(Int_t id) { fHCId = id; }
 
  protected:
   Int_t fId;              // index in tracklet array
-  Int_t fLabel;           // MC label
+  Int_t fLabel[3];        // MC label
   Int_t fHCId;            // half-chamber ID
   UInt_t fTrackletWord;   // tracklet word: PID | Z | deflection length | Y
                           //          bits:   8   4            7          13

--- a/STEER/ESD/AliESDEvent.cxx
+++ b/STEER/ESD/AliESDEvent.cxx
@@ -1355,7 +1355,7 @@ void AliESDEvent::AddTrdTracklet(const AliESDTrdTracklet *trkl)
 }
 
 //______________________________________________________________________________
-void AliESDEvent::AddTrdTracklet(UInt_t trackletWord, Short_t hcid, Int_t label)
+void AliESDEvent::AddTrdTracklet(UInt_t trackletWord, Short_t hcid, const Int_t* label)
 {
   new ((*fTrdTracklets)[fTrdTracklets->GetEntriesFast()]) AliESDTrdTracklet(trackletWord, hcid, label);
 }
@@ -2696,9 +2696,11 @@ void AliESDEvent::AdjustMCLabels(const AliVEvent *mcTruth)
   // TRD tracklets
   for (int itr=GetNumberOfTrdTracklets();itr--;) {
     AliESDTrdTracklet* trdTklet = GetTrdTracklet(itr);
-    lbraw = trdTklet->GetLabel();
-    if (lbraw<0) continue;
-    trdTklet->SetLabel(mcEvent->Raw2MergedLabel(lbraw));    
+    for (int i=3;i--;) {
+      lbraw = trdTklet->GetLabel(i);
+      if (lbraw<0) continue;
+      trdTklet->SetLabel(i,mcEvent->Raw2MergedLabel(lbraw));
+    }
   }
   // TRD tracks
   for (int itr=GetNumberOfTrdTracks();itr--;) {

--- a/STEER/ESD/AliESDEvent.h
+++ b/STEER/ESD/AliESDEvent.h
@@ -466,7 +466,7 @@ public:
   }
 
   void AddTrdTracklet(const AliESDTrdTracklet *trkl);
-  void AddTrdTracklet(UInt_t trackletWord, Short_t hcid, Int_t label = -1);
+  void AddTrdTracklet(UInt_t trackletWord, Short_t hcid, const Int_t *label = 0);
 
   using AliVEvent::GetV0;
   AliESDv0 *GetV0(Int_t i) const {

--- a/STEER/ESD/AliESDTrdTracklet.cxx
+++ b/STEER/ESD/AliESDTrdTracklet.cxx
@@ -28,20 +28,24 @@ ClassImp(AliESDTrdTracklet)
 AliESDTrdTracklet::AliESDTrdTracklet() :
   AliVTrdTracklet(),
   fHCId(-1),
-  fTrackletWord(0),
-  fLabel(-1)
+  fTrackletWord(0)
 {
   // default ctor
-
+  for (int i=3;i--;) fLabel[i] = -1;
 }
 
-AliESDTrdTracklet::AliESDTrdTracklet(UInt_t trackletWord, Short_t hcid, Int_t label) :
+AliESDTrdTracklet::AliESDTrdTracklet(UInt_t trackletWord, Short_t hcid, const Int_t* label) :
   AliVTrdTracklet(),
   fHCId(hcid),
-  fTrackletWord(trackletWord),
-  fLabel(label)
+  fTrackletWord(trackletWord)
 {
   // ctor with given tracklet word (and label)
+  if (label) {
+    for (int i=3;i--;) fLabel[i] = label[i];
+  }
+  else {
+    for (int i=3;i--;) fLabel[i] = -1;
+  }
 }
 
 AliESDTrdTracklet::~AliESDTrdTracklet()
@@ -52,11 +56,10 @@ AliESDTrdTracklet::~AliESDTrdTracklet()
 AliESDTrdTracklet::AliESDTrdTracklet(const AliESDTrdTracklet &trkl) :
   AliVTrdTracklet(trkl),
   fHCId(trkl.fHCId),
-  fTrackletWord(trkl.fTrackletWord),
-  fLabel(trkl.fLabel)
+  fTrackletWord(trkl.fTrackletWord)
 {
   // copy ctor
-
+  for (int i=3;i--;) fLabel[i] = trkl.fLabel[i];
 }
 
 AliESDTrdTracklet& AliESDTrdTracklet::operator=(const AliESDTrdTracklet &trkl)
@@ -69,8 +72,8 @@ AliESDTrdTracklet& AliESDTrdTracklet::operator=(const AliESDTrdTracklet &trkl)
   AliVTrdTracklet::operator=(trkl);
   fHCId = trkl.fHCId;
   fTrackletWord = trkl.fTrackletWord;
-  fLabel = trkl.fLabel;
-
+  for (int i=3;i--;) fLabel[i] = trkl.fLabel[i];
+  
   return *this;
 }
 

--- a/STEER/ESD/AliESDTrdTracklet.h
+++ b/STEER/ESD/AliESDTrdTracklet.h
@@ -12,14 +12,15 @@ class AliESDTrdTracklet : public AliVTrdTracklet
 {
  public:
   AliESDTrdTracklet();
-  AliESDTrdTracklet(UInt_t trackletWord, Short_t hcid, Int_t label = -1);
+  AliESDTrdTracklet(UInt_t trackletWord, Short_t hcid, const Int_t *label=0);
   AliESDTrdTracklet(const AliESDTrdTracklet &trkl);
   AliESDTrdTracklet& operator=(const AliESDTrdTracklet &trkl);
   ~AliESDTrdTracklet();
 
   void SetTrackletWord(UInt_t trklWord) { fTrackletWord = trklWord; }
   void SetHCId(Short_t hcid) { fHCId = hcid; }
-  void SetLabel(Int_t label) { fLabel = label; }
+  void SetLabel(Int_t label[]) { for (int i=3;i--;) fLabel[i] = label[i]; }
+  void SetLabel(int ilb, Int_t label) { fLabel[ilb] = label; }
 
   // ----- tracklet information -----
   virtual UInt_t GetTrackletWord() const { return fTrackletWord; }
@@ -35,16 +36,19 @@ class AliESDTrdTracklet : public AliVTrdTracklet
   Int_t GetMCM() const { return -1; }
 
   // ----- MC information -----
-  Int_t GetLabel() const { return fLabel; }
-
+  Int_t GetLabel()         const { return fLabel[0]; }
+  Int_t GetLabel(int i)    const { return fLabel[i]; }
+  const Int_t* GetLabels() const { return fLabel; }
+  
  protected:
   Short_t fHCId;		// half-chamber ID
 
   UInt_t fTrackletWord;		// tracklet word (as from FEE)
 				// pppp : pppp : zzzz : dddd : dddy : yyyy : yyyy : yyyy
-  Int_t  fLabel;		// MC label
+  Int_t  fLabel[3];		// MC labels
 
-  ClassDef(AliESDTrdTracklet, 2);
+  ClassDef(AliESDTrdTracklet, 3);
+
 };
 
 #endif

--- a/STEER/ESD/ESDLinkDef.h
+++ b/STEER/ESD/ESDLinkDef.h
@@ -99,6 +99,10 @@ code="{fTrackTime = new Double32_t[AliPID::kSPECIESC];for(Int_t isp=AliPID::kSPE
 #pragma link C++ class  AliESDTrdTrigger+;
 #pragma link C++ class  AliESDTrdTrack+;
 #pragma link C++ class  AliESDTrdTracklet+;
+#pragma read sourceClass="AliESDTrdTracklet" targetClass="AliESDTrdTracklet" \
+  source="Int_t fLabel" version="[-2]"	target="fLabel" targetType="Int_t[3]"\
+  code="{fLabel[0]=onfile.fLabel; fLabel[1]=fLabel[2]=-1;}"
+ 
 #pragma link C++ class  AliESDHLTtrack+;
 #pragma link C++ class  AliESDv0+;
 #pragma link C++ class  AliESDcascade+;

--- a/TRD/TRDbase/AliTRDReconstructor.cxx
+++ b/TRD/TRDbase/AliTRDReconstructor.cxx
@@ -293,9 +293,9 @@ void AliTRDReconstructor::FillESD(TTree* /*digitsTree*/
   AliTRDrawStream::SortTracklets(fgTracklets, trklList, trackletIndex);
   TIter trackletIter(&trklList);
   while (AliTRDtrackletBase* tracklet = (AliTRDtrackletBase*) trackletIter()) {
-    Int_t label = -2; // mark raw tracklets with label -2
-    if (AliTRDtrackletMCM *trklMCM = dynamic_cast<AliTRDtrackletMCM*> (tracklet)) label = trklMCM->GetLabel();
-    esd->AddTrdTracklet(tracklet->GetTrackletWord(), tracklet->GetHCId(), label);
+    const Int_t* labels = 0; // mark raw tracklets with label -2
+    if (AliTRDtrackletMCM *trklMCM = dynamic_cast<AliTRDtrackletMCM*> (tracklet)) labels = trklMCM->GetLabels();
+    esd->AddTrdTracklet(tracklet->GetTrackletWord(), tracklet->GetHCId(), labels);
   }
 
   // ----- filling GTU tracks -----

--- a/TRD/TRDbase/AliTRDtrackletMCM.h
+++ b/TRD/TRDbase/AliTRDtrackletMCM.h
@@ -35,6 +35,7 @@ class AliTRDtrackletMCM : public AliTRDtrackletBase {
   Int_t GetROB() const { return fROB; }
   Int_t GetLabel() const { return fLabel[0]; }
   Int_t GetLabel(const Int_t i) const { return fLabel[i]; }
+  const int* GetLabels() const {return fLabel;}
   Bool_t HasLabel(const Int_t label) const { return (fLabel[0] == label || fLabel[1] == label || fLabel[2] == label); }
 
   // ----- Getters for offline corresponding values -----


### PR DESCRIPTION
Propagate from MCM tracklets to AliESDTrdTracklets all 3 available labels (-1 means for non-assigned labels), use them when creating AliHLTTRDTrackletWord. 